### PR TITLE
Fix for POST|PUT|DELETE requests that do not have a request body

### DIFF
--- a/src/LeaseWeb/ChefGuzzle/Plugin/ChefAuth/ChefAuthPlugin.php
+++ b/src/LeaseWeb/ChefGuzzle/Plugin/ChefAuth/ChefAuthPlugin.php
@@ -65,6 +65,9 @@ class ChefAuthPlugin implements EventSubscriberInterface
         $request = $event['request'];
 
         if ('Guzzle\Http\Message\EntityEnclosingRequest' === get_class($request)) {
+            if (null === $request->getBody()) {
+                $request->setBody('{}');
+            }
             $hashedBody = $this->chunkedBase64Encode(Stream::getHash($request->getBody(), 'sha1', true));
         } else {
             $hashedBody = $this->sha1AndBase64Encode('');


### PR DESCRIPTION
For POST|PUT|DELETE requests Guzzle's `Request->getBody()` returns `null`.
In case of empty request bodies chef server api expects a json object.
